### PR TITLE
[Bug] Fix dependency between configuration and event sources

### DIFF
--- a/esf.tf
+++ b/esf.tf
@@ -213,7 +213,8 @@ resource "aws_lambda_event_source_mapping" "esf-event-source-mapping-kinesis-dat
   starting_position = "TRIM_HORIZON"
   enabled           = true
 
-  depends_on        = [module.esf-lambda-function]
+  # We should wait for the update of the config.yaml
+  depends_on = [module.esf-lambda-function, aws_s3_object.config-file]
 }
 
 resource "aws_lambda_event_source_mapping" "esf-event-source-mapping-sqs" {
@@ -222,7 +223,8 @@ resource "aws_lambda_event_source_mapping" "esf-event-source-mapping-sqs" {
   function_name    = module.esf-lambda-function.lambda_function_arn
   enabled          = true
 
-  depends_on        = [module.esf-lambda-function]
+  # We should wait for the update of the config.yaml
+  depends_on = [module.esf-lambda-function, aws_s3_object.config-file]
 }
 
 resource "aws_lambda_event_source_mapping" "esf-event-source-mapping-s3-sqs" {
@@ -231,7 +233,8 @@ resource "aws_lambda_event_source_mapping" "esf-event-source-mapping-s3-sqs" {
   function_name    = module.esf-lambda-function.lambda_function_arn
   enabled          = true
 
-  depends_on        = [module.esf-lambda-function]
+  # We should wait for the update of the config.yaml
+  depends_on = [module.esf-lambda-function, aws_s3_object.config-file]
 }
 
 resource "aws_lambda_permission" "esf-cloudwatch-logs-invoke-function-permission" {
@@ -240,9 +243,6 @@ resource "aws_lambda_permission" "esf-cloudwatch-logs-invoke-function-permission
   function_name = module.esf-lambda-function.lambda_function_name
   principal     = "logs.${split(":", each.value)[3]}.amazonaws.com"
   source_arn    = each.value
-
-  # It needs to depend on the update on config.yaml file, to avoid triggering the lambda before it
-  depends_on        = [aws_s3_object.config-file]
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "esf-cloudwatch-log-subscription-filter" {
@@ -251,7 +251,9 @@ resource "aws_cloudwatch_log_subscription_filter" "esf-cloudwatch-log-subscripti
   destination_arn = module.esf-lambda-function.lambda_function_arn
   filter_pattern  = ""
   log_group_name  = split(":", each.value)[6]
-  depends_on      = [aws_lambda_permission.esf-cloudwatch-logs-invoke-function-permission]
+
+  # We should wait for the update of the config.yaml
+  depends_on = [aws_lambda_permission.esf-cloudwatch-logs-invoke-function-permission, aws_s3_object.config-file]
 }
 
 resource "aws_lambda_event_source_mapping" "esf-event-source-mapping-continuing-queue" {


### PR DESCRIPTION
The events that trigger the ESF lambda need to depend on the `config.yaml` file. Otherwise, the ESF lambda can get triggered, and it might use the previous version of `config.yaml`  in the S3 bucket. We need to prevent that by making sure the file is always updated first, before ESF executes. 


### How to test

> Note: To see the bug you need to remove the changes made on this PR.

I am testing the bug based on this [example](https://github.com/elastic/elastic-serverless-forwarder/tree/main/dev-corner#patch-2-replay-queue-and-cloudwatch-logs-wrong-password-are-inputs).

First use a `config.yaml` file for cloudwatch logs group with the wrong API key. I am using the `inputs` variable so the changes are detected in each `apply` instead of the local `config.yaml`:

```terraform
inputs = [
  {
    type = "cloudwatch-logs"
    id   = "arn:aws:logs:eu-west-2:627286350134:log-group:constanca-test-local-esf:*"
    outputs = [
      {
        type = "elasticsearch"
        args = {
          elasticsearch_url  = "..."
          api_key            = "<Wrong key"
          es_datastream_name = "logs-esf.cloudwatch-default"
        }
      }
    ]
  },
]
```

I send a message to trigger ESF and to get the message in the replay queue. After that happens, I will update the `inputs` variable like this:

```terraform
inputs = [
  {
    type = "sqs"
    id   = "arn:aws:sqs:eu-west-2:627286350134:constanca-test-esf-replay-queue"
    outputs = [
      {
        type = "elasticsearch"
        args = {
          elasticsearch_url  = "< does not matter>"
          api_key            = "< does not matter>"
          es_datastream_name = "< does not matter>"
        }
      }
    ]
  },
  {
    type = "cloudwatch-logs"
    id   = "arn:aws:logs:eu-west-2:627286350134:log-group:constanca-test-local-esf:*"
    outputs = [
      {
        type = "elasticsearch"
        args = {
          elasticsearch_url  = "..."
          api_key            = "<Correct key"
          es_datastream_name = "logs-esf.cloudwatch-default"
        }
      }
    ]
  },
]
```

If the message in the replay queue fails to be sent again, then we know the `config.yaml` file was updated after the event source for the replay queue was set - since the event in the replay queue is the trigger for the ESF lambda handler - , which is not supposed to happen.

This does not happen all the time, it can only be seen some times.
