### PR TITLE
Add support for Python 3.12 runtime

### DIFF
--- a/esf.tf
+++ b/esf.tf
@@ -124,6 +124,20 @@ locals {
     minor = tonumber(local.release-version-unpacked[1])
     patch = tonumber(local.release-version-unpacked[2])
   }
+
+  # Select Lambda runtime based on release-version
+  #
+  # - If the major version is less than 1, use python3.9.
+  # - If the major version is 1 and the minor version is less than 20, use python3.9.
+  # - Otherwise, use python3.12.
+  #
+  lambda_runtime = (
+    local.release-version-parts.major < 1 ||
+    (
+      local.release-version-parts.major == 1 &&
+      local.release-version-parts.minor < 20
+    )
+  ) ? "python3.9" : "python3.12"
 }
 
 check "esf-release" {
@@ -176,7 +190,7 @@ module "esf-lambda-function" {
 
   function_name = var.lambda-name
   handler       = "main_aws.lambda_handler"
-  runtime       = "python3.9"
+  runtime       = local.lambda_runtime
   architectures = ["x86_64"]
   timeout       = var.lambda-timeout
 


### PR DESCRIPTION
Add support for Python runtime 3.12.

Starting from release v1.20.0, all ESF versions will use the Python runtime 3.12. With this change, the infrastructure will pick the correct runtime based on the ESF version.

We decided only to support a single runtime for each ESF release.

| Header | Header |
|--------|--------|
| <= 1.19.0 | `python3.9` | 
| >= 1.20.0 | `python3.12` | 

We can consider supporting multiple runtime versions for the same ESF release in the future. However, today it doesn't seem worth continuing to support `python3.9`.

Supporting multiple runtimes requires a rework in the build system to include extension's `.so` files for all supported Python versions. 

Closes #18