### PR TITLE
Remove ec2:DescribeRegions permissions from lambda role

### DIFF
--- a/esf.tf
+++ b/esf.tf
@@ -115,10 +115,6 @@ locals {
     s3-buckets-list_bucket = { effect = "Allow", actions = ["s3:ListBucket"], resources = var.s3-buckets },
     s3-buckets-get_object  = { effect = "Allow", actions = ["s3:GetObject"], resources = [for arn in var.s3-buckets : "${arn}/*"] }
   } : {})
-
-  ec2 = (length(local.cloudwatch-logs-arns) > 0 ? {
-    ec2 = { effect = "Allow", actions = ["ec2:DescribeRegions"], resources = ["*"] } } : {}
-  )
 }
 
 resource "aws_s3_bucket" "esf-config-bucket" {
@@ -205,8 +201,7 @@ module "esf-lambda-function" {
     local.sqs,
     local.ssm-secrets,
     local.kms-keys,
-    local.s3-buckets,
-    local.ec2
+    local.s3-buckets
   )
 
   use_existing_cloudwatch_log_group = false

--- a/esf.tf
+++ b/esf.tf
@@ -129,8 +129,9 @@ locals {
 check "esf-release" {
   assert {
     condition = (
-      (local.release-version-parts.major >= 1 && local.release-version-parts.minor > 7) ||
-      (local.release-version-parts.major >= 1 && local.release-version-parts.minor == 7 && local.release-version-parts.patch >= 2)
+      (local.release-version-parts.major > 1) ||
+      (local.release-version-parts.major == 1 && local.release-version-parts.minor > 7) ||
+      (local.release-version-parts.major == 1 && local.release-version-parts.minor == 7 && local.release-version-parts.patch >= 2)
     )
     # Why version 1.7.2? Because before that version, ESF was listing the regions and required the `ec2:DescribeRegions` permission.
     # See https://github.com/elastic/elastic-serverless-forwarder/pull/811

--- a/esf.tf
+++ b/esf.tf
@@ -129,10 +129,8 @@ locals {
 check "esf-release" {
   assert {
     condition = (
-      local.release-version-parts.major > 1 ||
-      (
-        local.release-version-parts.major == 1 && local.release-version-parts.minor >= 7 && local.release-version-parts.patch >= 2
-      )
+      (local.release-version-parts.major >= 1 && local.release-version-parts.minor > 7) ||
+      (local.release-version-parts.major >= 1 && local.release-version-parts.minor == 7 && local.release-version-parts.patch >= 2)
     )
     # Why version 1.7.2? Because before that version, ESF was listing the regions and required the `ec2:DescribeRegions` permission.
     # See https://github.com/elastic/elastic-serverless-forwarder/pull/811

--- a/esf.tf
+++ b/esf.tf
@@ -134,6 +134,8 @@ check "esf-release" {
         local.release-version-parts.major == 1 && local.release-version-parts.minor >= 7 && local.release-version-parts.patch >= 2
       )
     )
+    # Why version 1.7.2? Because before that version, ESF was listing the regions and required the `ec2:DescribeRegions` permission.
+    # See https://github.com/elastic/elastic-serverless-forwarder/pull/811
     error_message = "Release version ${var.release-version} is not supported. Please use a version >= 1.7.2"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,11 @@ variable "lambda-name" {
 variable "release-version" {
   description = "ESF release version. You can find the possible values in https://github.com/elastic/elastic-serverless-forwarder/tags."
   type        = string
+
+  validation {
+    condition     = can(regex("^lambda-v[0-9]+\\.[0-9]+\\.[0-9]+$", var.release-version))
+    error_message = "The release-version must match the format lambda-v<major>.<minor>.<patch>. For example, lambda-v1.20.0."
+  }
 }
 
 variable "aws_region" {


### PR DESCRIPTION
Remove the `ec2:DescribeRegions` permission from the lambda role.

ESF no longer needs this permission. For more details, please see https://github.com/elastic/elastic-serverless-forwarder/pull/811.