### PR TITLE
fix: remove deprecated provider definition from module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,12 +22,3 @@ terraform {
     }
   }
 }
-
-provider "aws" {
-  region = var.aws_region
-}
-
-
-
-
-


### PR DESCRIPTION
It is no longer good practice for module to define a provider block. 
https://developer.hashicorp.com/terraform/language/modules/develop/providers#legacy-shared-modules-with-provider-configurations