### PR TITLE
Add IAM Role ARN as input variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,10 +24,11 @@ terraform {
 }
 
 provider "aws" {
+  dynamic "assume_role" {
+    for_each = var.aws_connection_role_arn != null ? [1] : []
+    content {
+      role_arn = var.aws_connection_role_arn
+    }
+  }
   region = var.aws_region
 }
-
-
-
-
-

--- a/variables.tf
+++ b/variables.tf
@@ -25,6 +25,12 @@ variable "aws_region" {
   type        = string
 }
 
+variable "aws_connection_role_arn" {
+  description = "IAM Role ARN for Terraform to assume when authenticating with AWS"
+  type        = string
+  default     = null
+}
+
 variable "log_level" {
   description = "Log level for ESF"
   type        = string


### PR DESCRIPTION
This change introduces the optional `aws_connection_role_arn` variable to allow the AWS provider to assume a specific IAM role during deployment.

It is interesting for teams that relay on the AWS IAM roles to provide limited access to the operations/resources available in AWS.

It has been tested when deploying the ESF for our own infrastructure. 