### PR TITLE
Add optional tags inside inputs variable

### DIFF
--- a/esf.tf
+++ b/esf.tf
@@ -27,6 +27,7 @@ locals {
     {
       id : input.id,
       type : input.type,
+      tags: input.tags,
       outputs : [
         for output in input.outputs : {
           type : output.type

--- a/variables.tf
+++ b/variables.tf
@@ -57,6 +57,7 @@ EOT
   type = list(object({
     type = string
     id   = string
+    tags = optional(any, [])
     outputs = list(object({
       type = string
       args = object({


### PR DESCRIPTION
This change adds a `tags` input variable to the ESF configuration, allowing users to inject custom metadata directly into the ESF config.yaml.

It is interesting to include additional information in the logs sent to Elasticsearch.

It has been tested when deploying the ESF for our own infrastructure. 